### PR TITLE
Fixes the minus sign shift after a factorial (Closes #23)

### DIFF
--- a/BigEval.js
+++ b/BigEval.js
@@ -631,10 +631,11 @@ BigEval.prototype.compile = function (expression) {
 			continue;
 		}
 
+		// When we have something like this: "5*-1", we will move the "-" to be part of the number token.
 		if (token.type === TokenType.NUMBER &&
 			prevToken.type === TokenType.OP &&
 			(prevToken.value === '-' || prevToken.value === '+') &&
-			((i > 1 && tokens[i - 2].type === TokenType.OP) || i === 1)
+			((i > 1 && tokens[i - 2].type === TokenType.OP && this.suffixOps.indexOf(tokens[i - 2].value) === -1) || i === 1)
 			) {
 
 			if (prevToken.value === '-') {

--- a/tests/testmain.js
+++ b/tests/testmain.js
@@ -25,6 +25,11 @@ exports.testBasics = {
 		test.done();
 	},
 
+	testFactorial: function(test){
+		test.equals(this.b.exec("2*5!+3"), 243);
+		test.done();
+	},
+
 	testEnclosedNegative: function(test){
 		test.equals(Math.round(this.b.exec("(-5)+6")), 1);
 		test.done();
@@ -67,7 +72,7 @@ exports.testBasics = {
 
 	testExp: function(test){
 		test.equals(this.b.exec("1e1 + 1e+2 + 1e-3"), 110.001);
- 		test.done();
+		test.done();
 	},
 
 	testConstProvider: function(test){


### PR DESCRIPTION
Does the same thing as #23, working with the `suffixOps`, adding an explanation, and fixing the test to call done.

